### PR TITLE
PBSO-559 Add Guzzle 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jimdo/prometheus_client_php",
+    "name": "justpark/prometheus_client_php",
     "authors": [
         {
             "name": "Joscha",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "justpark/prometheus_client_php",
+    "name": "jimdo/prometheus_client_php",
     "authors": [
         {
             "name": "Joscha",

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
             "email": "jan.brauer@jimdo.com"
         }
     ],
+    "replace": {
+        "jimdo/prometheus_client_php": "*"
+    },
     "require": {
         "php": ">=5.6.3",
         "guzzlehttp/guzzle": "^6.3|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.6.3",
-        "guzzlehttp/guzzle": "^6.2",
+        "guzzlehttp/guzzle": "^6.3|^7.0",
         "symfony/polyfill-apcu": "^1.6"
     },
     "require-dev": {


### PR DESCRIPTION
Required for the Laravel 8 upgrade, will need to tag following the merge and reference this tag in justpark/justpark